### PR TITLE
#89 Fixed 'brief description', added quantity of item in cart instead

### DIFF
--- a/resources/views/order/index.blade.php
+++ b/resources/views/order/index.blade.php
@@ -65,7 +65,7 @@
         <li class="list-group-item d-flex justify-content-between lh-condensed">
           <div>
             <h6 class="my-0">{{ $product->name }}</h6>
-            <small class="text-muted">Brief description</small>
+            <small class="text-muted">Quantity: {{$product->qty}}</small>
           </div>
           <span class="text-muted">{{ $product->price }}</span>
         </li>


### PR DESCRIPTION
Doesn't show 'brief description' anymore, replaced it with the quantity of the item